### PR TITLE
Add user creation to Homebrew installation instructions for Postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ If you're on OSX and have [Homebrew](https://brew.sh/) installed, you can simply
 
 ```bash
 brew install postgresql
+/usr/local/opt/postgres/bin/createuser -s postgres
 ```
 
 ### Postgres.app


### PR DESCRIPTION
Prevents an error `error: role "postgres" does not exist` when seeding example data.